### PR TITLE
Add PHP 7.1 to the travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 cache:
   directories:


### PR DESCRIPTION
Should we remove PHP 5.5 because it's EOL'ed?