### PR TITLE
Add minimum required PHP version as composer requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,6 @@
 {
   "name": "matthiasnoback/convenient-immutability",
   "description": "Make objects initially inconsistent, yet eventually immutable",
-  "require-dev": {
-    "symfony/form": "~2.0",
-    "phpunit/phpunit": "~4.0",
-    "ramsey/uuid": "^3.1",
-    "satooshi/php-coveralls": "^1.0"
-  },
   "license": "MIT",
   "authors": [
     {
@@ -14,6 +8,15 @@
       "email": "matthiasnoback@gmail.com"
     }
   ],
+  "require": {
+    "php": ">=5.4"
+  },
+  "require-dev": {
+    "symfony/form": "~2.0",
+    "phpunit/phpunit": "~4.0",
+    "ramsey/uuid": "^3.1",
+    "satooshi/php-coveralls": "^1.0"
+  },
   "autoload": {
     "psr-4": {
       "ConvenientImmutability\\": "src/"


### PR DESCRIPTION
Technically at least PHP 5.4 is required because of the short array syntax.
But PHP 5.4 is not in the travis test matrix so we don't know for sure if everything works.

As PHP 5.6 is the oldest officially supported PHP version maybe we should require this instead?